### PR TITLE
Allow options to be passed.  Allow { extname : false } 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ gulp.task('create-json-blob', function() {
 });
 ```
 
+Options may be included. `extname` as false removes file extensions and this is useful when wanting dot notation, `flat` as true removes the path and therefore the resulting json object is one layer deep. Be careful to avoid duplicate filenames when using the flat option.
+
+```javascript
+      .pipe(fc2json('contents.json', {
+        extname : false, // default is true
+        flat : true // default is false
+      }))
+```
+
 Simply run the following and you're done:
 
 ```shell

--- a/index.js
+++ b/index.js
@@ -9,8 +9,12 @@ nconf.file({ file: 'store.json' });
 
 var PLUGIN_NAME = 'gulp-file-contents-to-json';
 
-module.exports = function (dest) {
-
+module.exports = function (dest, options) {
+  
+  // set defaults for options here
+  options = options ? options : {};
+  
+  
   var first = null;
   var guid = 'xxxxxxxx-xxxx-4xxx-yxxx'.replace(/[xy]/g, function(c) {
     var r = Math.random()*16|0,v=c==='x'?r:r&0x3|0x8;return v.toString(16);
@@ -41,6 +45,19 @@ module.exports = function (dest) {
       //
       first = first || file;
       var id = file.path.replace(file.base, '').split('/').join(':');   // 'foo/bar/bax.txt' => 'foo:bar:baz.txt'
+      
+      if (options.extname === false) { 
+        // 'foo:bar:baz.txt' => 'foo:bar:baz'
+        //http://stackoverflow.com/questions/4250364/how-to-trim-a-file-extension-from-a-string-in-javascript
+        id = id.replace(/\.[^/.]+$/, '');  
+      }; 
+
+      if (options.flat === true) { 
+        // 'foo:bar:baz.txt' => 'baz.txt'
+        // 'foo:bar:baz' => 'baz'
+        id = id.split(':').reverse()[0]; 
+      }; 
+
       var contents = file.contents.toString("utf-8");
       nconf.set(guid + ':' + id, contents);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-file-contents-to-json",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Slurp in some files, output a JSON representation of their contents.",
   "main": "index.js",
   "repository": "briangonzalez/gulp-file-contents-to-json",


### PR DESCRIPTION
Allow options to be passed.    

Allow { extname : false }  to be passed in as options and this will prevent the filename extension appearing in the keys of the output.

Goal is to allow dot notation in referencing
