### PR TITLE
Support flatpath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ gulp.task('create-json-blob', function() {
 });
 ```
 
-Options may be included. `extname` as false removes file extensions and this is useful when wanting dot notation, `flat` as true removes the path and therefore the resulting json object is one layer deep. Be careful to avoid duplicate filenames when using the flat option.
+Options may be included. `extname` as false removes file extensions and this is useful when wanting dot notation. `flat` as true removes the path and therefore the resulting json object is one layer deep (be careful to avoid duplicate filenames when using the flat option). `flatpath` will like `flat` result in a one layer deep json object, but where the path is included, separated with double underscores.
 
 ```javascript
       .pipe(fc2json('contents.json', {
         extname : false, // default is true
-        flat : true // default is false
+        flat : true, // default is false
+        flatpath: true // default is false
       }))
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,14 +56,15 @@ gulp.task('create-json-blob', function() {
 ```
 
 Options may be included. `extname` as false removes file extensions and this is useful when wanting dot notation. 
-`flat` as true removes the path and therefore the resulting json object is one layer deep (be careful to avoid duplicate filenames when using the flat option). 
-`flatpathdelimiter` will like `flat` result in a one layer deep json object, but where the path is included, separated with the custom delimiter set in `flatpathdelimiter`.
+`delimiter` will customize the delimiter separating the directory names and file name in the path instead of creating a layered json object.
+`flat` as true (while keeping `includeDirs` as false) a removes the path and therefore the resulting json object is one layer deep (be careful to avoid duplicate filenames when using the flat option with directories not included). 
 
 ```javascript
       .pipe(fc2json('contents.json', {
         extname : false, // default is true
         flat : true, // default is false
-        flatpathdelimiter: '__' // default is not set, delimiter will be ':'
+        delimiter: '__', // default is not set, delimiter will be ':'
+        includeDirs: true // default is false
       }))
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ gulp.task('create-json-blob', function() {
 });
 ```
 
-Options may be included. `extname` as false removes file extensions and this is useful when wanting dot notation. `flat` as true removes the path and therefore the resulting json object is one layer deep (be careful to avoid duplicate filenames when using the flat option). `flatpath` will like `flat` result in a one layer deep json object, but where the path is included, separated with double underscores.
+Options may be included. `extname` as false removes file extensions and this is useful when wanting dot notation. 
+`flat` as true removes the path and therefore the resulting json object is one layer deep (be careful to avoid duplicate filenames when using the flat option). 
+`flatpathdelimiter` will like `flat` result in a one layer deep json object, but where the path is included, separated with the custom delimiter set in `flatpathdelimiter`.
 
 ```javascript
       .pipe(fc2json('contents.json', {
         extname : false, // default is true
         flat : true, // default is false
-        flatpath: true // default is false
+        flatpathdelimiter: '__' // default is not set, delimiter will be ':'
       }))
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,15 +56,14 @@ gulp.task('create-json-blob', function() {
 ```
 
 Options may be included. `extname` as false removes file extensions and this is useful when wanting dot notation. 
-`delimiter` will customize the delimiter separating the directory names and file name in the path instead of creating a layered json object.
-`flat` as true (while keeping `includeDirs` as false) a removes the path and therefore the resulting json object is one layer deep (be careful to avoid duplicate filenames when using the flat option with directories not included). 
+`flat` as true removes the path and therefore the resulting json object is one layer deep (be careful to avoid duplicate filenames when using the flat option). 
+`flatpathdelimiter` will like `flat` result in a one layer deep json object, but where the path is included, separated with the custom delimiter set in `flatpathdelimiter`.
 
 ```javascript
       .pipe(fc2json('contents.json', {
         extname : false, // default is true
         flat : true, // default is false
-        delimiter: '__', // default is not set, delimiter will be ':'
-        includeDirs: true // default is false
+        flatpathdelimiter: '__' // default is not set, delimiter will be ':'
       }))
 ```
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function (dest, options) {
       // Use nconf to create a json object of our files.
       //
       first = first || file;
-      var delimiter = (options.flatpathdelimiter) ? options.flatpathdelimiter : ':'; // Support for custom delimiter
+      var delimiter = (options.delimiter) ? options.delimiter : ':'; // Support for custom delimiter
       var id = file.path.replace(file.base, '').replace(/\\/g,'/').split('/').join(delimiter);   // 'foo/bar/bax.txt' => 'foo:bar:baz.txt'
       
       if (options.extname === false) { 
@@ -53,10 +53,10 @@ module.exports = function (dest, options) {
         id = id.replace(/\.[^/.]+$/, '');  
       }; 
 
-      if (options.flat === true) { 
+      if (options.flat === true && !options.includeDirs) {
         // 'foo:bar:baz.txt' => 'baz.txt'
         // 'foo:bar:baz' => 'baz'
-        id = id.split(':').reverse()[0]; 
+        id = id.split(delimiter).reverse()[0];
       }; 
 
       var contents = file.contents.toString("utf-8");

--- a/index.js
+++ b/index.js
@@ -58,6 +58,12 @@ module.exports = function (dest, options) {
         id = id.split(':').reverse()[0]; 
       }; 
 
+      if (options.flatpath === true) {
+        // 'foo:bar:baz.txt' => 'foo__bar__baz.txt'
+        // 'foo:bar:baz' => 'foo__bar__baz'
+        id = id.replace(/:/g,'__');
+      }
+
       var contents = file.contents.toString("utf-8");
       nconf.set(guid + ':' + id, contents);
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ module.exports = function (dest, options) {
       // Use nconf to create a json object of our files.
       //
       first = first || file;
-      var id = file.path.replace(file.base, '').split('/').join(':');   // 'foo/bar/bax.txt' => 'foo:bar:baz.txt'
+      var delimiter = (options.flatpathdelimiter) ? options.flatpathdelimiter : ':'; // Support for custom delimiter
+      var id = file.path.replace(file.base, '').split('/').join(delimiter);   // 'foo/bar/bax.txt' => 'foo:bar:baz.txt'
       
       if (options.extname === false) { 
         // 'foo:bar:baz.txt' => 'foo:bar:baz'
@@ -57,12 +58,6 @@ module.exports = function (dest, options) {
         // 'foo:bar:baz' => 'baz'
         id = id.split(':').reverse()[0]; 
       }; 
-
-      if (options.flatpath === true) {
-        // 'foo:bar:baz.txt' => 'foo__bar__baz.txt'
-        // 'foo:bar:baz' => 'foo__bar__baz'
-        id = id.replace(/:/g,'__');
-      }
 
       var contents = file.contents.toString("utf-8");
       nconf.set(guid + ':' + id, contents);

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function (dest, options) {
       // Use nconf to create a json object of our files.
       //
       first = first || file;
-      var delimiter = (options.delimiter) ? options.delimiter : ':'; // Support for custom delimiter
+      var delimiter = (options.flatpathdelimiter) ? options.flatpathdelimiter : ':'; // Support for custom delimiter
       var id = file.path.replace(file.base, '').replace(/\\/g,'/').split('/').join(delimiter);   // 'foo/bar/bax.txt' => 'foo:bar:baz.txt'
       
       if (options.extname === false) { 
@@ -53,10 +53,10 @@ module.exports = function (dest, options) {
         id = id.replace(/\.[^/.]+$/, '');  
       }; 
 
-      if (options.flat === true && !options.includeDirs) {
+      if (options.flat === true) { 
         // 'foo:bar:baz.txt' => 'baz.txt'
         // 'foo:bar:baz' => 'baz'
-        id = id.split(delimiter).reverse()[0];
+        id = id.split(':').reverse()[0]; 
       }; 
 
       var contents = file.contents.toString("utf-8");


### PR DESCRIPTION
`flatpath` will like `flat` result in a one layer deep json object, but where the path is included, separated with double underscores
