### PR TITLE
Add a strip option that will use a RegExp to strip off a portion of the filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,17 @@ gulp.task('create-json-blob', function() {
 });
 ```
 
-Options may be included. `extname` as false removes file extensions and this is useful when wanting dot notation. 
-`flat` as true removes the path and therefore the resulting json object is one layer deep (be careful to avoid duplicate filenames when using the flat option). 
-`flatpathdelimiter` will like `flat` result in a one layer deep json object, but where the path is included, separated with the custom delimiter set in `flatpathdelimiter`.
+Options may be included.
+* `extname` as false removes file extensions and this is useful when wanting dot notation.
+* `strip` takes a RegExp to strip content off the file name. This is useful if you have a directory of template files (e.g. contactTemplate.html, hoursTemplate.html) and need to strip the "Template" naming convention off each file.
+* `flat` as true removes the path and therefore the resulting json object is one layer deep (be careful to avoid duplicate filenames when using the flat option).
+* `flatpathdelimiter` will like `flat` result in a one layer deep json object, but where the path is included, separated with the custom delimiter set in `flatpathdelimiter`.
 
 ```javascript
       .pipe(fc2json('contents.json', {
-        extname : false, // default is true
-        flat : true, // default is false
+        extname: false, // default is true
+        strip: /Template/, // default is not set
+        flat: true, // default is false
         flatpathdelimiter: '__' // default is not set, delimiter will be ':'
       }))
 ```

--- a/index.js
+++ b/index.js
@@ -10,11 +10,11 @@ nconf.file({ file: 'store.json' });
 var PLUGIN_NAME = 'gulp-file-contents-to-json';
 
 module.exports = function (dest, options) {
-  
+
   // set defaults for options here
   options = options ? options : {};
-  
-  
+
+
   var first = null;
   var guid = 'xxxxxxxx-xxxx-4xxx-yxxx'.replace(/[xy]/g, function(c) {
     var r = Math.random()*16|0,v=c==='x'?r:r&0x3|0x8;return v.toString(16);
@@ -46,18 +46,22 @@ module.exports = function (dest, options) {
       first = first || file;
       var delimiter = (options.flatpathdelimiter) ? options.flatpathdelimiter : ':'; // Support for custom delimiter
       var id = file.path.replace(file.base, '').replace(/\\/g,'/').split('/').join(delimiter);   // 'foo/bar/bax.txt' => 'foo:bar:baz.txt'
-      
-      if (options.extname === false) { 
+
+      if (options.extname === false) {
         // 'foo:bar:baz.txt' => 'foo:bar:baz'
         //http://stackoverflow.com/questions/4250364/how-to-trim-a-file-extension-from-a-string-in-javascript
-        id = id.replace(/\.[^/.]+$/, '');  
-      }; 
+        id = id.replace(/\.[^/.]+$/, '');
+      };
 
-      if (options.flat === true) { 
+      if (options.strip instanceof RegExp) {
+        id = id.replace(options.strip, '');
+      };
+
+      if (options.flat === true) {
         // 'foo:bar:baz.txt' => 'baz.txt'
         // 'foo:bar:baz' => 'baz'
-        id = id.split(':').reverse()[0]; 
-      }; 
+        id = id.split(':').reverse()[0];
+      };
 
       var contents = file.contents.toString("utf-8");
       nconf.set(guid + ':' + id, contents);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-file-contents-to-json",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Slurp in some files, output a JSON representation of their contents.",
   "main": "index.js",
   "repository": "briangonzalez/gulp-file-contents-to-json",


### PR DESCRIPTION
This pull request adds an option to use a RegExp to remove part of the file name.

We had a use case where we have a dozen or so template files stored in a directory that all ended in "Template.html". Using the `extname` option, we could remove the ".html", but we also needed "Template" gone on each one.

Now we can use `strip: /Template/` as an option to remove that portion from each file name.
